### PR TITLE
[fix] cmakefile tune

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/external/grassland/external/vcpkg/scripts/buildsystems/vcpkg.cmake)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+
 project(GameX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -45,44 +45,43 @@ void RegularBall::UpdateTick() {
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  /*auto owner = world_->GetPlayer(player_id_);
-  if (owner) {
-    if (UnitId() == owner->PrimaryUnitId()) {
-      auto input = owner->TakePlayerInput();
-
-      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
-      glm::vec3 right =
-          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
-
-      glm::vec3 moving_direction{};
-
-      float angular_acceleration = glm::radians(2880.0f);
-
-      if (input.move_forward) {
-        moving_direction -= right;
-      }
-      if (input.move_backward) {
-        moving_direction += right;
-      }
-      if (input.move_left) {
-        moving_direction -= forward;
-      }
-      if (input.move_right) {
-        moving_direction += forward;
-      }
-
-      if (glm::length(moving_direction) > 0.0f) {
-        moving_direction = glm::normalize(moving_direction);
-        sphere.angular_velocity +=
-            moving_direction * angular_acceleration * delta_time;
-      }
-
-      if (input.brake) {
-        sphere.angular_velocity = glm::vec3{0.0f};
-      }
-    }
-  }*/
-
+  //  auto owner = world_->GetPlayer(player_id_);
+  //  if (owner) {
+  //    if (UnitId() == owner->PrimaryUnitId()) {
+  //      auto input = owner->TakePlayerInput();
+  //
+  //      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
+  //      glm::vec3 right =
+  //          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
+  //
+  //      glm::vec3 moving_direction{};
+  //
+  //      float angular_acceleration = glm::radians(2880.0f);
+  //
+  //      if (input.move_forward) {
+  //        moving_direction -= right;
+  //      }
+  //      if (input.move_backward) {
+  //        moving_direction += right;
+  //      }
+  //      if (input.move_left) {
+  //        moving_direction -= forward;
+  //      }
+  //      if (input.move_right) {
+  //        moving_direction += forward;
+  //      }
+  //
+  //      if (glm::length(moving_direction) > 0.0f) {
+  //        moving_direction = glm::normalize(moving_direction);
+  //        sphere.angular_velocity +=
+  //            moving_direction * angular_acceleration * delta_time;
+  //      }
+  //
+  //      if (input.brake) {
+  //        sphere.angular_velocity = glm::vec3{0.0f};
+  //      }
+  //    }
+  //  }
 
   sphere.velocity *= std::pow(0.5f, delta_time);
   sphere.angular_velocity *= std::pow(0.2f, delta_time);

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -45,7 +45,7 @@ void RegularBall::UpdateTick() {
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  auto owner = world_->GetPlayer(player_id_);
+  /*auto owner = world_->GetPlayer(player_id_);
   if (owner) {
     if (UnitId() == owner->PrimaryUnitId()) {
       auto input = owner->TakePlayerInput();
@@ -81,7 +81,7 @@ void RegularBall::UpdateTick() {
         sphere.angular_velocity = glm::vec3{0.0f};
       }
     }
-  }
+  }*/
 
 
   sphere.velocity *= std::pow(0.5f, delta_time);

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -45,43 +45,44 @@ void RegularBall::UpdateTick() {
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  //  auto owner = world_->GetPlayer(player_id_);
-  //  if (owner) {
-  //    if (UnitId() == owner->PrimaryUnitId()) {
-  //      auto input = owner->TakePlayerInput();
-  //
-  //      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
-  //      glm::vec3 right =
-  //          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
-  //
-  //      glm::vec3 moving_direction{};
-  //
-  //      float angular_acceleration = glm::radians(2880.0f);
-  //
-  //      if (input.move_forward) {
-  //        moving_direction -= right;
-  //      }
-  //      if (input.move_backward) {
-  //        moving_direction += right;
-  //      }
-  //      if (input.move_left) {
-  //        moving_direction -= forward;
-  //      }
-  //      if (input.move_right) {
-  //        moving_direction += forward;
-  //      }
-  //
-  //      if (glm::length(moving_direction) > 0.0f) {
-  //        moving_direction = glm::normalize(moving_direction);
-  //        sphere.angular_velocity +=
-  //            moving_direction * angular_acceleration * delta_time;
-  //      }
-  //
-  //      if (input.brake) {
-  //        sphere.angular_velocity = glm::vec3{0.0f};
-  //      }
-  //    }
-  //  }
+  auto owner = world_->GetPlayer(player_id_);
+  if (owner) {
+    if (UnitId() == owner->PrimaryUnitId()) {
+      auto input = owner->TakePlayerInput();
+
+      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
+      glm::vec3 right =
+          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
+
+      glm::vec3 moving_direction{};
+
+      float angular_acceleration = glm::radians(2880.0f);
+
+      if (input.move_forward) {
+        moving_direction -= right;
+      }
+      if (input.move_backward) {
+        moving_direction += right;
+      }
+      if (input.move_left) {
+        moving_direction -= forward;
+      }
+      if (input.move_right) {
+        moving_direction += forward;
+      }
+
+      if (glm::length(moving_direction) > 0.0f) {
+        moving_direction = glm::normalize(moving_direction);
+        sphere.angular_velocity +=
+            moving_direction * angular_acceleration * delta_time;
+      }
+
+      if (input.brake) {
+        sphere.angular_velocity = glm::vec3{0.0f};
+      }
+    }
+  }
+
 
   sphere.velocity *= std::pow(0.5f, delta_time);
   sphere.angular_velocity *= std::pow(0.2f, delta_time);

--- a/src/GameX/utils/utils.cpp
+++ b/src/GameX/utils/utils.cpp
@@ -2,7 +2,7 @@
 
 namespace GameX::Base {
 
-glm::mat3 Base::Rotate(const glm::vec3 &axis, float radians) {
+glm::mat3 Rotate(const glm::vec3 &axis, float radians) {
   float c = cos(radians);
   float s = sin(radians);
   float t = 1.0f - c;
@@ -14,7 +14,7 @@ glm::mat3 Base::Rotate(const glm::vec3 &axis, float radians) {
                    t * x * z + y * s, t * y * z - x * s, t * z * z + c);
 }
 
-glm::mat3 Base::Rotate(const glm::vec3 &rotation) {
+glm::mat3 Rotate(const glm::vec3 &rotation) {
   float theta = glm::length(rotation);
   if (theta < 0.0001f) {
     return glm::mat3(1.0f);


### PR DESCRIPTION
In `render.h` RenderPipeline is declared as a function, while in `render_pipeline.h` RenderPipeline is declared as a class, which does cause errors under strict C++ standard (at least in Linux on my pc). So I add `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")` to relax the restriction.
Also fix a wrong declaration.