### PR TITLE
[feat] Ball type changing, enlarging, shrinking

### DIFF
--- a/src/GameBall/core/game_ball.cpp
+++ b/src/GameBall/core/game_ball.cpp
@@ -26,6 +26,7 @@ GameBall::~GameBall() {
 
 void GameBall::OnInit() {
   auto world = logic_manager_->World();
+  float ground_size = 40.0f;
 
   scene_->SetEnvmapImage(asset_manager_->ImageFile("textures/envmap.hdr"));
 
@@ -42,10 +43,11 @@ void GameBall::OnInit() {
   auto enemy_unit = world->CreateUnit<Logic::Units::RegularBall>(
       enemy_player->PlayerId(), glm::vec3{-5.0f, 1.0f, 0.0f}, 1.0f, 1.0f);
   auto primary_obstacle = world->CreateObstacle<Logic::Obstacles::Block>(
-      glm::vec3{0.0f, -10.0f, 0.0f}, std::numeric_limits<float>::infinity(),
-      false, 20.0f);
+      glm::vec3{0.0f, -ground_size, 0.0f},
+      std::numeric_limits<float>::infinity(), false, 2 * ground_size);
 
   primary_player_id_ = primary_player->PlayerId();
+  enemy_player_id_ = enemy_player->PlayerId();
 
   primary_player->SetPrimaryUnit(primary_unit->UnitId());
 

--- a/src/GameBall/core/game_ball.h
+++ b/src/GameBall/core/game_ball.h
@@ -70,6 +70,7 @@ class GameBall : public GameX::Base::Application {
   std::unique_ptr<CameraControllerThirdPerson> camera_controller_;
 
   uint64_t primary_player_id_{0};
+  uint64_t enemy_player_id_{0};
   uint64_t primary_player_primary_unit_object_id_{0};
 
   bool ignore_next_mouse_move_{true};

--- a/src/GameBall/logic/player_input.cpp
+++ b/src/GameBall/logic/player_input.cpp
@@ -14,6 +14,9 @@ PlayerInput PlayerInputController::GetInput() {
   input_.move_left = (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS);
   input_.move_right = (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS);
   input_.brake = (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS);
+  input_.left_arrow = (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS);
+  input_.right_arrow = (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS);
+  input_.restart = (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS);
   auto camera_controller = app_->CameraController();
   auto pitch_yaw = camera_controller->GetPitchYaw();
   auto pitch = pitch_yaw.x;

--- a/src/GameBall/logic/player_input.cpp
+++ b/src/GameBall/logic/player_input.cpp
@@ -8,6 +8,7 @@ PlayerInputController::PlayerInputController(GameBall *app) : app_(app) {
 
 PlayerInput PlayerInputController::GetInput() {
   auto window = app_->Window();
+  input_.speed_up = (glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS);
   input_.move_forward = (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS);
   input_.move_backward = (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS);
   input_.move_left = (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS);

--- a/src/GameBall/logic/player_input.cpp
+++ b/src/GameBall/logic/player_input.cpp
@@ -17,6 +17,8 @@ PlayerInput PlayerInputController::GetInput() {
   input_.left_arrow = (glfwGetKey(window, GLFW_KEY_LEFT) == GLFW_PRESS);
   input_.right_arrow = (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS);
   input_.restart = (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS);
+  input_.grow = (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS);
+  input_.shrink = (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS);
   auto camera_controller = app_->CameraController();
   auto pitch_yaw = camera_controller->GetPitchYaw();
   auto pitch = pitch_yaw.x;

--- a/src/GameBall/logic/player_input.h
+++ b/src/GameBall/logic/player_input.h
@@ -13,6 +13,9 @@ struct PlayerInput {
   bool move_right{false};
   bool speed_up{false};
   bool brake{false};
+  bool left_arrow{false};
+  bool right_arrow{false};
+  bool restart{false};
   glm::vec3 orientation{0.0f, 0.0f, 1.0f};
 };
 

--- a/src/GameBall/logic/player_input.h
+++ b/src/GameBall/logic/player_input.h
@@ -16,6 +16,8 @@ struct PlayerInput {
   bool left_arrow{false};
   bool right_arrow{false};
   bool restart{false};
+  bool grow{false};
+  bool shrink{false};
   glm::vec3 orientation{0.0f, 0.0f, 1.0f};
 };
 

--- a/src/GameBall/logic/player_input.h
+++ b/src/GameBall/logic/player_input.h
@@ -11,6 +11,7 @@ struct PlayerInput {
   bool move_backward{false};
   bool move_left{false};
   bool move_right{false};
+  bool speed_up{false};
   bool brake{false};
   glm::vec3 orientation{0.0f, 0.0f, 1.0f};
 };

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -46,7 +46,7 @@ void RegularBall::UpdateTick() {
   cur_time += delta_time;
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
-  bool speed_up = false;
+  bool speed_up = false, restart = false;
   float delta_v = 0.5f, delta_av = 0.2f;
   auto owner = world_->GetPlayer(player_id_);
 
@@ -74,15 +74,16 @@ void RegularBall::UpdateTick() {
       if (input.move_right) {
         moving_direction += forward;
       }
-      if (input.left_arrow && (cur_time-last_change_time>=1.0)) {
+      if (input.left_arrow && (cur_time - last_change_time >= 1.0)) {
         sphere.type = (sphere.type - 1) < 0 ? 2 : (sphere.type - 1);
         last_change_time = cur_time;
       }
-      if (input.right_arrow && (cur_time-last_change_time>=1.0)) {
+      if (input.right_arrow && (cur_time - last_change_time >= 1.0)) {
         sphere.type = (sphere.type + 1) % 3;
         last_change_time = cur_time;
       }
       speed_up = input.speed_up;
+      restart = input.restart || sphere.position.y <= -3.0f;
 
       if (glm::length(moving_direction) > 0.0f) {
         moving_direction = glm::normalize(moving_direction);
@@ -105,12 +106,17 @@ void RegularBall::UpdateTick() {
   sphere.friction = sphere.frictions[sphere.type];
   sphere.mass = sphere.masses[sphere.type];
 
-
-
-  position_ = sphere.position;
-  velocity_ = sphere.velocity;
-  orientation_ = sphere.orientation;
-  augular_momentum_ = sphere.inertia * sphere.angular_velocity;
+  if(!restart){
+    position_ = sphere.position;
+    velocity_ = sphere.velocity;
+    orientation_ = sphere.orientation;
+    augular_momentum_ = sphere.inertia * sphere.angular_velocity;
+  }else{
+    position_ = sphere.position = glm::vec3{0.0f, sphere.radius + 0.1f, 0.0f};
+    velocity_ = sphere.velocity = glm::vec3{0.0f};
+    augular_momentum_ = sphere.angular_velocity = glm::vec3{0.0f};
+    orientation_ = sphere.orientation = glm::mat3{1.0f};
+  }
 }
 
 void RegularBall::SetMass(float mass) {

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -45,43 +45,43 @@ void RegularBall::UpdateTick() {
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  //  auto owner = world_->GetPlayer(player_id_);
-  //  if (owner) {
-  //    if (UnitId() == owner->PrimaryUnitId()) {
-  //      auto input = owner->TakePlayerInput();
-  //
-  //      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
-  //      glm::vec3 right =
-  //          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
-  //
-  //      glm::vec3 moving_direction{};
-  //
-  //      float angular_acceleration = glm::radians(2880.0f);
-  //
-  //      if (input.move_forward) {
-  //        moving_direction -= right;
-  //      }
-  //      if (input.move_backward) {
-  //        moving_direction += right;
-  //      }
-  //      if (input.move_left) {
-  //        moving_direction -= forward;
-  //      }
-  //      if (input.move_right) {
-  //        moving_direction += forward;
-  //      }
-  //
-  //      if (glm::length(moving_direction) > 0.0f) {
-  //        moving_direction = glm::normalize(moving_direction);
-  //        sphere.angular_velocity +=
-  //            moving_direction * angular_acceleration * delta_time;
-  //      }
-  //
-  //      if (input.brake) {
-  //        sphere.angular_velocity = glm::vec3{0.0f};
-  //      }
-  //    }
-  //  }
+    auto owner = world_->GetPlayer(player_id_);
+    if (owner) {
+      if (UnitId() == owner->PrimaryUnitId()) {
+        auto input = owner->TakePlayerInput();
+
+        glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
+        glm::vec3 right =
+            glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
+
+        glm::vec3 moving_direction{};
+
+        float angular_acceleration = glm::radians(2880.0f);
+
+        if (input.move_forward) {
+          moving_direction -= right;
+        }
+        if (input.move_backward) {
+          moving_direction += right;
+        }
+        if (input.move_left) {
+          moving_direction -= forward;
+        }
+        if (input.move_right) {
+          moving_direction += forward;
+        }
+
+        if (glm::length(moving_direction) > 0.0f) {
+          moving_direction = glm::normalize(moving_direction);
+          sphere.angular_velocity +=
+              moving_direction * angular_acceleration * delta_time;
+        }
+
+        if (input.brake) {
+          sphere.angular_velocity = glm::vec3{0.0f};
+        }
+      }
+    }
 
   sphere.velocity *= std::pow(0.5f, delta_time);
   sphere.angular_velocity *= std::pow(0.2f, delta_time);

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -44,47 +44,52 @@ void RegularBall::UpdateTick() {
   float delta_time = world_->TickDeltaT();
   auto physics_world = world_->PhysicsWorld();
   auto &sphere = physics_world->GetSphere(sphere_id_);
+  bool speed_up = false;
 
-    auto owner = world_->GetPlayer(player_id_);
-    if (owner) {
-      if (UnitId() == owner->PrimaryUnitId()) {
-        auto input = owner->TakePlayerInput();
+  auto owner = world_->GetPlayer(player_id_);
+  if (owner) {
+    if (UnitId() == owner->PrimaryUnitId()) {
+      auto input = owner->TakePlayerInput();
 
-        glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
-        glm::vec3 right =
-            glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
+      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
+      glm::vec3 right =
+          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
 
-        glm::vec3 moving_direction{};
+      glm::vec3 moving_direction{};
 
-        float angular_acceleration = glm::radians(2880.0f);
+      float angular_acceleration = glm::radians(2880.0f);
 
-        if (input.move_forward) {
-          moving_direction -= right;
-        }
-        if (input.move_backward) {
-          moving_direction += right;
-        }
-        if (input.move_left) {
-          moving_direction -= forward;
-        }
-        if (input.move_right) {
-          moving_direction += forward;
-        }
+      if (input.move_forward) {
+        moving_direction -= right;
+      }
+      if (input.move_backward) {
+        moving_direction += right;
+      }
+      if (input.move_left) {
+        moving_direction -= forward;
+      }
+      if (input.move_right) {
+        moving_direction += forward;
+      }
+      speed_up = input.speed_up;
 
-        if (glm::length(moving_direction) > 0.0f) {
-          moving_direction = glm::normalize(moving_direction);
-          sphere.angular_velocity +=
-              moving_direction * angular_acceleration * delta_time;
-        }
+      if (glm::length(moving_direction) > 0.0f) {
+        moving_direction = glm::normalize(moving_direction);
+        sphere.angular_velocity +=
+            moving_direction * angular_acceleration * delta_time;
+      }
 
-        if (input.brake) {
-          sphere.angular_velocity = glm::vec3{0.0f};
-        }
+      if (input.brake) {
+        sphere.angular_velocity = glm::vec3{0.0f};
       }
     }
+  }
 
-  sphere.velocity *= std::pow(0.5f, delta_time);
-  sphere.angular_velocity *= std::pow(0.2f, delta_time);
+  float delta_v = 0.5f, delta_av = 0.2f;
+  if (speed_up)
+    delta_v *= 3.0f, delta_av *= 3.0f;
+  sphere.velocity *= std::pow(delta_v, delta_time);
+  sphere.angular_velocity *= std::pow(delta_av, delta_time);
 
   position_ = sphere.position;
   velocity_ = sphere.velocity;

--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -75,13 +75,29 @@ void RegularBall::UpdateTick() {
       if (input.move_right) {
         moving_direction += forward;
       }
-      if (input.left_arrow && (cur_time - last_change_time >= 1.0)) {
+      if (input.left_arrow && (cur_time - last_change_time >= 1.0) && sphere.radius == 1.0f) {
         sphere.type = (sphere.type - 1) < 0 ? 2 : (sphere.type - 1);
         last_change_time = cur_time;
+        LAND_INFO("Sphere changed into type {}.", sphere.type);
       }
-      if (input.right_arrow && (cur_time - last_change_time >= 1.0)) {
+      if (input.right_arrow && (cur_time - last_change_time >= 1.0) && sphere.radius == 1.0f) {
         sphere.type = (sphere.type + 1) % 3;
         last_change_time = cur_time;
+        LAND_INFO("Sphere changed into type {}.", sphere.type);
+      }
+      if(input.shrink && (cur_time - last_change_time >= 1.0) && sphere.radius > 0.25f){
+        sphere.position = sphere.position + glm::vec3{0.0f,-0.5f * sphere.radius,0.0f};
+        sphere.radius *= 0.5f;
+        sphere.mass *= 0.125f;
+        last_change_time = cur_time;
+        LAND_INFO("Sphere shrank.");
+      }
+      if(input.grow && (cur_time - last_change_time >= 1.0) && sphere.radius < 4.0f){
+        sphere.position = sphere.position + glm::vec3{0.0f,sphere.radius,0.0f};
+        sphere.radius *= 2.0f;
+        sphere.mass *= 8.0f;
+        last_change_time = cur_time;
+        LAND_INFO("Sphere enlarged.");
       }
       if (input.brake) {
         sphere.angular_velocity *= 0.7f;
@@ -93,7 +109,7 @@ void RegularBall::UpdateTick() {
         sphere.velocity *= std::pow(delta_v, delta_time);
         sphere.angular_velocity *= std::pow(delta_av, delta_time);
       }
-      restart = input.restart || sphere.position.y <= -3.0f;
+      restart = input.restart || sphere.position.y <= -7.0f;
       if (restart) {
         sphere.position = glm::vec3{0.0f, sphere.radius + 0.1f, 0.0f};
       }
@@ -111,7 +127,7 @@ void RegularBall::UpdateTick() {
       // Controls enemy ball
       sphere.velocity *= std::pow(delta_v, delta_time);
       sphere.angular_velocity *= std::pow(delta_av, delta_time);
-      if (sphere.position.y <= -3.0f) {
+      if (sphere.position.y <= -7.0f) {
         sphere.position = glm::vec3{-5.0f, sphere.radius + 0.1f, 0.0f};
         restart = true;
       }

--- a/src/GameX/physics/sphere.h
+++ b/src/GameX/physics/sphere.h
@@ -10,5 +10,9 @@ struct Sphere : public RigidBody {
   void SetRadiusMass(float radius = 1.0f, float mass = 1.0f);
 
   float radius{1.0f};
+  int type = 0;
+  float elasticities[3] = {1.0f, 3.0f, 5.0f};
+  float masses[3] = {1.0f, 0.6f, 0.3f};
+  float frictions[3] = {10.0f, 20.0f, 30.0f};
 };
 }  // namespace GameX::Physics

--- a/src/GameX/physics/sphere.h
+++ b/src/GameX/physics/sphere.h
@@ -11,8 +11,8 @@ struct Sphere : public RigidBody {
 
   float radius{1.0f};
   int type = 0;
-  float elasticities[3] = {1.0f, 3.0f, 5.0f};
-  float masses[3] = {1.0f, 0.6f, 0.3f};
-  float frictions[3] = {10.0f, 20.0f, 30.0f};
+  float elasticities[3] = {1.0f, 2.0f, 3.0f};
+  float masses[3] = {1.0f, 0.7f, 0.5f};
+  float frictions[3] = {10.0f, 13.0f, 15.0f};
 };
 }  // namespace GameX::Physics


### PR DESCRIPTION
We can now change the type of the ball by using left and right arrow keys! Also, we may change the radius (and spontaneously the mass) of the ball by using up and down arrow keys. However, I have not yet solved the problem of texture and model changing during game, so the display will be a bit weird if you enlarge/shrink the ball.
Partly solves #73 