### PR TITLE
[Feat] Player Input Handling and Sphere Control Implementation

### DIFF
--- a/src/GameBall/logic/units/regular_ball.cpp
+++ b/src/GameBall/logic/units/regular_ball.cpp
@@ -42,54 +42,45 @@ SYNC_ACTOR_FUNC(RegularBall) {
 
 void RegularBall::UpdateTick() {
   float delta_time = world_->TickDeltaT();
-  auto physics_world = world_->PhysicsWorld();
-  auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  //  auto owner = world_->GetPlayer(player_id_);
-  //  if (owner) {
-  //    if (UnitId() == owner->PrimaryUnitId()) {
-  //      auto input = owner->TakePlayerInput();
-  //
-  //      glm::vec3 forward = glm::normalize(glm::vec3{input.orientation});
-  //      glm::vec3 right =
-  //          glm::normalize(glm::cross(forward, glm::vec3{0.0f, 1.0f, 0.0f}));
-  //
-  //      glm::vec3 moving_direction{};
-  //
-  //      float angular_acceleration = glm::radians(2880.0f);
-  //
-  //      if (input.move_forward) {
-  //        moving_direction -= right;
-  //      }
-  //      if (input.move_backward) {
-  //        moving_direction += right;
-  //      }
-  //      if (input.move_left) {
-  //        moving_direction -= forward;
-  //      }
-  //      if (input.move_right) {
-  //        moving_direction += forward;
-  //      }
-  //
-  //      if (glm::length(moving_direction) > 0.0f) {
-  //        moving_direction = glm::normalize(moving_direction);
-  //        sphere.angular_velocity +=
-  //            moving_direction * angular_acceleration * delta_time;
-  //      }
-  //
-  //      if (input.brake) {
-  //        sphere.angular_velocity = glm::vec3{0.0f};
-  //      }
-  //    }
-  //  }
+  auto owner = world_->GetPlayer(player_id_); 
+  if (owner) {
+    auto physics_world = world_->PhysicsWorld();
+    auto &sphere = physics_world->GetSphere(sphere_id_);
 
-  sphere.velocity *= std::pow(0.5f, delta_time);
-  sphere.angular_velocity *= std::pow(0.2f, delta_time);
+    if (UnitId() == owner->PrimaryUnitId()) {
+      auto input = owner->TakePlayerInput();
+      
+      glm::vec3 forward = glm::normalize(input.orientation);
+      glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3(0.0f, 1.0f, 0.0f)));
 
-  position_ = sphere.position;
-  velocity_ = sphere.velocity;
-  orientation_ = sphere.orientation;
-  augular_momentum_ = sphere.inertia * sphere.angular_velocity;
+      glm::vec3 moving_direction{};
+
+      float angular_acceleration = glm::radians(2880.0f);
+
+      
+      if (input.move_forward) moving_direction -= right;
+      if (input.move_backward) moving_direction += right;
+      if (input.move_left) moving_direction -= forward;
+      if (input.move_right) moving_direction += forward;
+
+      if (glm::length(moving_direction) > 0.0f) {
+        moving_direction = glm::normalize(moving_direction);
+        sphere.angular_velocity += moving_direction * angular_acceleration * delta_time;
+      }
+
+     
+      if (input.brake) sphere.angular_velocity = glm::vec3(0.0f);
+    
+      sphere.velocity *= std::pow(0.5f, delta_time);
+      sphere.angular_velocity *= std::pow(0.2f, delta_time);
+    }
+
+    position_ = sphere.position;
+    velocity_ = sphere.velocity;
+    orientation_ = sphere.orientation;
+    augular_momentum_ = sphere.inertia * sphere.angular_velocity;
+  }
 }
 
 void RegularBall::SetMass(float mass) {


### PR DESCRIPTION
This PR implements the handling of player input to control the movement and braking of regular ball units. 

Changes include:
- Implemented mapping from key input to player-directed ball movement.
- Added braking functionality on space bar press, stopping all angular motion.
- Included necessary force and direction calculations for velocity and rotation.


Close #4


